### PR TITLE
Missing serde `tag` for `SystemMessage`

### DIFF
--- a/src/structures/channels/message.rs
+++ b/src/structures/channels/message.rs
@@ -28,6 +28,7 @@ pub struct SendableEmbed {
 }
 /// Representation of a system event message
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type")]
 pub enum SystemMessage {
     #[serde(rename = "text")]
     Text { content: String },


### PR DESCRIPTION
`SystemMessage` was missing a `#[serde(tag = "type")]` line which basically broke deserializing with stuff like `message_query`.
This PR addresses these issues.
