### PR TITLE
fix: `/users/{target}/block`, `/bots/{target}/invite`, feat: add `discriminator` and `display_name` `User` fields

### DIFF
--- a/src/client/methods/bot.rs
+++ b/src/client/methods/bot.rs
@@ -41,28 +41,33 @@ impl Client {
             .await
     }
 
-    pub async fn bot_invite(&self, bot_id: &str, server_or_group: &str) -> Result<(), DeltaError> {
+    pub async fn bot_invite(
+        &self,
+        bot_id: &str,
+        server_or_group: &str,
+        is_server: bool,
+    ) -> Result<(), DeltaError> {
+        let data = if is_server {
+            DataBotInvite::Server {
+                server: server_or_group.to_string(),
+            }
+        } else {
+            DataBotInvite::Group {
+                group: server_or_group.to_string(),
+            }
+        };
+
         self.http
-            .request(
-                Method::POST,
-                &format!("/bots/{bot_id}/invite"),
-                json!(DataBotInvite::from(server_or_group)),
-            )
+            .request(Method::POST, &format!("/bots/{bot_id}/invite"), json!(data))
             .await
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct DataBotInvite {
-    pub server: String,
-}
-
-impl From<&str> for DataBotInvite {
-    fn from(value: &str) -> Self {
-        DataBotInvite {
-            server: String::from(value),
-        }
-    }
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum DataBotInvite {
+    Server { server: String },
+    Group { group: String },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/src/client/methods/user.rs
+++ b/src/client/methods/user.rs
@@ -65,7 +65,7 @@ impl Client {
 
     pub async fn user_block(&self, user: &str) -> Result<User, DeltaError> {
         self.http
-            .request(Method::POST, &format!("/users/{user}/block"), None)
+            .request(Method::PUT, &format!("/users/{user}/block"), None)
             .await
     }
 

--- a/src/structures/users/mod.rs
+++ b/src/structures/users/mod.rs
@@ -67,6 +67,10 @@ pub struct UserProfile {
     /// Text content on user's profile
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+
+    /// Banner on user's profile
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background: Option<File>,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -120,6 +124,12 @@ pub struct User {
     pub id: String,
     /// Username
     pub username: String,
+    /// User discriminator (#1234)
+    pub discriminator: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// User's display name
+    pub display_name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Avatar attachment

--- a/src/tests/bots.rs
+++ b/src/tests/bots.rs
@@ -78,7 +78,7 @@ mod tests {
     async fn test_bot_invite() {
         let client = test_client(false);
 
-        if let Err(error) = client.bot_invite(BOT, SERVER).await {
+        if let Err(error) = client.bot_invite(BOT, SERVER, true).await {
             panic!("{:#?}", error);
         };
     }


### PR DESCRIPTION
Mainly fixes to a few routes that were missing edge cases or had a wrong method.
And adding the `discriminator` and `display_name` `User` fields to be deserialized by `serde`